### PR TITLE
JPro support for demo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,20 @@
       </developer>
     </developers>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jpro - sandec repository</id>
+            <url>https://sandec.jfrog.io/artifactory/repo/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <repositories>
+        <repository>
+            <id>jpro - sandec repository</id>
+            <url>https://sandec.jfrog.io/artifactory/repo/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
@@ -83,6 +97,12 @@
             <groupId>org.jfree</groupId>
             <artifactId>org.jfree.pdf</artifactId>
             <version>2.0</version>            
+        </dependency>
+
+        <dependency>
+            <groupId>com.sandec.jpro</groupId>
+            <artifactId>jpro-webapi</artifactId>
+            <version>${jpro.version}</version>
         </dependency>
     </dependencies>
     
@@ -171,12 +191,22 @@
                 <artifactId>maven-install-plugin</artifactId>
                 <version>3.0.0-M1</version>
             </plugin>
+
+            <plugin>
+                <groupId>one.jpro</groupId>
+                <artifactId>jpro-maven-plugin</artifactId>
+                <version>${jpro.version}</version>
+                <configuration>
+                    <mainClassName>org.jfree.chart3d.fx.demo.OrsonChartsFXDemo</mainClassName>
+                </configuration>
+            </plugin>
         </plugins> 
 
     </build>
 
 
     <properties>
+        <jpro.version>2023.2.2-SNAPSHOT</jpro.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.source.level>11</project.source.level>
         <project.target.level>11</project.target.level>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module org.jfree.fx.demos {
     requires org.jfree.jfreechart;
     requires org.jfree.chart.fx;
     requires org.jfree.fxgraphics2d;
+    requires jpro.webapi;
     exports org.jfree.chart3d.fx.demo;
     exports org.jfree.chart.fx.demo;
     exports org.jfree.fx.demo;

--- a/src/main/java/org/jfree/chart3d/fx/demo/OrsonChartsFXDemo.java
+++ b/src/main/java/org/jfree/chart3d/fx/demo/OrsonChartsFXDemo.java
@@ -42,10 +42,12 @@ import java.awt.geom.Dimension2D;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.io.*;
 
 import com.jpro.webapi.HTMLView;
 import com.jpro.webapi.WebAPI;
@@ -66,6 +68,8 @@ import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import org.jfree.chart3d.Chart3D;
 import org.jfree.chart3d.data.Dataset3D;
 import org.jfree.chart3d.data.category.CategoryDataset3D;
@@ -134,8 +138,12 @@ public class OrsonChartsFXDemo extends Application {
         if(WebAPI.isBrowser()) {
             try {
                 HTMLView htmlView = new HTMLView();
-                URL urlo = getClass().getResource(resource);
-                String content = new String(Files.readAllBytes(Paths.get(urlo.toURI())));
+                InputStream is = getClass().getResourceAsStream(resource);
+
+                String content = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
+                        .lines()
+                        .collect(Collectors.joining("\n"));
+
                 htmlView.setContent(content);
                 return htmlView;
             } catch (Exception e) {


### PR DESCRIPTION
Hi,

**JPro-Version:**
I've made the demo application run with JPro.
I also put the demo online: https://demos.jpro.one/jfree.html


**MemoryLeak:**
We found a memory leak with the default style.
It seems like listeners are added to the DefaultStyle. Afterwards the DefaultStyle references the old nodes forever.
As a workaround, I'm currently resetting the defaultStyle: `Chart3DFactory.setDefaultChartStyle(new StandardChartStyle());`


We've also noticed, that one of the demos only works sometimes (this is independent of JPro, it also happens in the pure JavaFX version.):
<img width="690" alt="Screenshot 2023-08-16 at 14 11 46" src="https://github.com/jfree/jfree-fxdemos/assets/6547435/e24a9d89-16e8-4a4e-a605-cfdf94d5e1e9">
